### PR TITLE
Move NodeUA to backend section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Please, see [this guide](CONTRIBUTING.md), if you want to contribute to this lis
 - [Scala Ukraine Telegram](https://t.me/scala_ukraine) - **Telegram** - Чат української спільноти Scala розробників.
 - [Terraform Ukraine Telegram](https://t.me/terraform_ukraine) - **Telegram** - Чат української Terraform спільноти.
 - [NestJS Ukraine Telegram](https://t.me/nest_ukraine) - **Telegram** - Чат української спільноти NestJS розробників.
+- [NodeUA - JavaScript and Node.js in Ukraine](https://t.me/nodeua) - **Telegram** - Чат по JavaScript та Node.js, чат спільноти Metarhia.
 
 ## Databases
 
@@ -81,7 +82,6 @@ Please, see [this guide](CONTRIBUTING.md), if you want to contribute to this lis
 - [IT KPI Dart](https://t.me/dart_itkpi) - **Telegram** - Чат ІТ KPI про Dart.
 - [React Kyiv](https://t.me/reactkyiv) - **Telegram** - Чат для спілкування React розробників.
 - [ІТ КПІ - JS](https://t.me/itkpi_js) - **Telegram** - Чат ІТ KPI для обговорення JS і Front-end.
-- [NodeUA - JavaScript and Node.js in Ukraine](https://t.me/nodeua) - **Telegram** - Чат по JavaScript та Node.js, чат спільноти Metarhia.
 
 ## Hardware & Embedded
 


### PR DESCRIPTION
NodeUA group is about backend development using JavaScript and nodejs, not frontend
