### PR TITLE
Remove UkrOps since the website is down

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ Please, see [this guide](CONTRIBUTING.md), if you want to contribute to this lis
 - [HashiCorp User Group Kyiv](https://www.meetup.com/Kyiv-HashiCorp-User-Group/) - **MeetUp** - This group is a place to meet other developers and ops engineers using HashiCorp tools.
 - [IT KPI - DevOps](https://t.me/itkpi_devops) - **Telegram** - Чат ІТ KPI про DevOps і Лінукс.
 - [UAFUG](https://groups.google.com/g/uafug) - **GoogleGroups** - Ukrainian FreeBSD User Group.
-- [UkrOps](https://ukrops.club/) - **Slack** - Международное сообщество украинских девопсов. Или украинское сообщество международных девопсов. Читайте как вам удобнее.
 - [Docker🐳/Kubernetes Українською](https://t.me/k8s_ua) - **Telegram** - Чат про Docker і Kubernetes.
 - [Sysadmin Tools](https://t.me/sysadmin_tools) - **Telegram** - Sysadmin/DevOps tools, news and other interesting things from modern IT world.
 - [Updates rtfm.co.ua](https://t.me/rtfmcoua) - **Telegram** - Канал про DevOps і українське IT в цілому.


### PR DESCRIPTION
Removing a stale community UkrOps, which doesn't exist any more.

<details>
<summary>Proof</summary>

https://www.uptrends.com/tools/uptime?toolRequestGuid=33f85aa4-a421-4b9e-ad6f-2db58b419184

<img width="1179" alt="image" src="https://github.com/grem11n/awesome-it-communities-ua/assets/3228886/bec14260-d714-4a6d-8be6-f133b8c675f4">

</details>

### Contributor's Checklist:

- [x] I have read and understood the [contribution rules](CONTRIBUTING.md). My submission complies with these rules.
- [x] My submission is grammatically correct.
- [x] My submission follows the [general Awesome List guidelines](https://github.com/sindresorhus/awesome/blob/main/pull_request_template.md). You can check it running the [Awesome Lint](https://github.com/sindresorhus/awesome-lint) locally. We also run linter on CI.

### By submitting this pull request I confirm I've read and complied with the below requirements 🖖
